### PR TITLE
feat: add `overshoot/server` entry point for Node.js environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
+    },
+    "./server": {
+      "types": "./dist/server.d.ts",
+      "import": "./dist/server.mjs",
+      "require": "./dist/server.js"
     }
   },
   "files": [

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,49 @@
+/**
+ * Server-safe entry point for Node.js / server-side environments.
+ *
+ * Exports StreamClient, types, and errors WITHOUT importing RealtimeVision,
+ * which depends on browser APIs (document, HTMLVideoElement, Canvas, etc.).
+ *
+ * Usage:
+ *   import { StreamClient } from 'overshoot/server';
+ *
+ * For browser environments, use the default entry point:
+ *   import { RealtimeVision, StreamClient } from 'overshoot';
+ */
+
+export { StreamClient } from "./client/client";
+export { DEFAULT_API_URL } from "./client/constants";
+export type {
+  StreamSource,
+  WebRtcOffer,
+  WebRtcAnswer,
+  WebRTCSourceConfig,
+  LiveKitSourceConfig,
+  SourceConfig,
+  StreamMode,
+  ClipProcessingConfig,
+  FrameProcessingConfig,
+  StreamProcessingConfig,
+  ModelBackend,
+  StreamInferenceConfig,
+  StreamClientMeta,
+  StreamCreateRequest,
+  StreamCreateResponse,
+  StreamInferenceResult,
+  StreamConfigResponse,
+  KeepaliveResponse,
+  StatusResponse,
+  ErrorResponse,
+  ModelStatus,
+  ModelInfo,
+  StreamStopReason,
+  FinishReason,
+} from "./client/types";
+export {
+  ApiError,
+  UnauthorizedError,
+  ValidationError,
+  NotFoundError,
+  NetworkError,
+  ServerError,
+} from "./client/errors";

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/server.ts"],
   format: ["cjs", "esm"],
   dts: true,
   splitting: false,


### PR DESCRIPTION
The current single entry point (`overshoot`) re-exports both `StreamClient` (server-safe) and `RealtimeVision` (browser-only) from the same bundle. When Node.js imports `StreamClient`, the module evaluator also loads `RealtimeVision` which references `document.createElement`, causing:

  ReferenceError: document is not defined

This adds a separate `overshoot/server` entry point that exports only server-safe code (StreamClient, types, errors) without importing RealtimeVision or any browser-dependent modules.

Usage:
  // Node.js / server-side (NEW)
  import { StreamClient } from 'overshoot/server';

  // Browser (unchanged)
  import { RealtimeVision, StreamClient } from 'overshoot';

Changes:
- Add `src/server.ts` - server-safe exports (no RealtimeVision)
- Add `./server` to package.json `exports` map
- Add `src/server.ts` to tsup entry points